### PR TITLE
refactor: use `class` instead of `className`

### DIFF
--- a/src/routes/style/+page.svelte
+++ b/src/routes/style/+page.svelte
@@ -17,7 +17,7 @@
 		<Chessground coordinates={false} />
 	</div>
 {:else if style_i == 1}
-	<ChessgroundUnstyled className="cg-paper" coordinates={false}/>
+	<ChessgroundUnstyled class="cg-paper" coordinates={false}/>
 {:else if style_i == 2}
 	<Chessground coordinates={false} />
 {/if}


### PR DESCRIPTION
If [https://github.com/gtim/svelte-chessground/pull/4](https://github.com/gtim/svelte-chessground/pull/4) gets merged, this example should be updated too to reflect the changes :)